### PR TITLE
Remove parantheses for the encrypted icon

### DIFF
--- a/excalidraw-app/components/AppFooter.tsx
+++ b/excalidraw-app/components/AppFooter.tsx
@@ -12,8 +12,7 @@ export const AppFooter = React.memo(() => {
           alignItems: "center",
         }}
       >
-        (
-        <EncryptedIcon />)
+        <EncryptedIcon />
       </div>
     </Footer>
   );


### PR DESCRIPTION
This PR removes the parantheses around the encrypted icon at the bottom right.